### PR TITLE
Using CronScheduler instead of ScheduledExecutorService in MonitorScheduler

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -226,6 +226,10 @@
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.timeandspace</groupId>
+      <artifactId>cron-scheduler</artifactId>
+    </dependency>
 
 
 

--- a/core/src/main/java/org/apache/druid/java/util/common/concurrent/ScheduledExecutors.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/concurrent/ScheduledExecutors.java
@@ -174,6 +174,11 @@ public class ScheduledExecutors
     scheduleAtFixedRate(exec, rate, rate, callable);
   }
 
+  /**
+   * Run callable once every period, after the given initial delay. Uses
+   * {@link CronScheduler} for task scheduling. Exceptions are caught and logged
+   * as errors.
+   */
   public static void scheduleAtFixedRate(
       final CronScheduler exec,
       final Duration initialDelay,

--- a/core/src/main/java/org/apache/druid/java/util/metrics/MonitorScheduler.java
+++ b/core/src/main/java/org/apache/druid/java/util/metrics/MonitorScheduler.java
@@ -27,11 +27,9 @@ import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ScheduledExecutorService;
 
 
 /**
@@ -39,27 +37,24 @@ import java.util.concurrent.ScheduledExecutorService;
 public class MonitorScheduler
 {
   private final MonitorSchedulerConfig config;
-  private final ScheduledExecutorService exec;
   private final ServiceEmitter emitter;
   private final Set<Monitor> monitors;
   private final Object lock = new Object();
-  private final Duration syncPeriod = Duration.ofSeconds(1L);
   private final CronScheduler scheduler;
 
   private volatile boolean started = false;
 
   public MonitorScheduler(
       MonitorSchedulerConfig config,
-      ScheduledExecutorService exec,
+      CronScheduler scheduler,
       ServiceEmitter emitter,
       List<Monitor> monitors
   )
   {
     this.config = config;
-    this.exec = exec;
+    this.scheduler = scheduler;
     this.emitter = emitter;
     this.monitors = Sets.newHashSet(monitors);
-    this.scheduler = CronScheduler.create(syncPeriod);
   }
 
   @LifecycleStart

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -345,6 +345,16 @@ libraries:
 
 ---
 
+name: CronScheduler
+license_category: binary
+module: java-core
+license_name: Apache License version 2.0
+version: 0.1
+libraries:
+  - io.timeandspace: cron-scheduler
+
+---
+
 name: LMAX Disruptor
 license_category: binary
 module: java-core

--- a/pom.xml
+++ b/pom.xml
@@ -1254,6 +1254,11 @@
                 <version>1.19.0</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>io.timeandspace</groupId>
+                <artifactId>cron-scheduler</artifactId>
+                <version>0.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
@@ -101,14 +101,16 @@ public class MetricsModule implements Module
       log.info(
           "Loaded %d monitors: %s",
           monitors.size(),
-          monitors.stream().map(monitor -> monitor.getClass().getName()).collect(Collectors.joining(", ")));
+          monitors.stream().map(monitor -> monitor.getClass().getName()).collect(Collectors.joining(", "))
+      );
     }
 
     return new MonitorScheduler(
         config.get(),
         CronScheduler.newBuilder(Duration.ofSeconds(1L)).setThreadName("MonitorScheduler-%s").build(),
         emitter,
-        monitors);
+        monitors
+    );
   }
 
   @Provides

--- a/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
@@ -27,11 +27,11 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
+import io.timeandspace.cronscheduler.CronScheduler;
 import org.apache.druid.guice.DruidBinders;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.guice.ManageLifecycle;
-import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.metrics.JvmCpuMonitor;
@@ -42,6 +42,7 @@ import org.apache.druid.java.util.metrics.MonitorScheduler;
 import org.apache.druid.java.util.metrics.SysMonitor;
 import org.apache.druid.query.ExecutorServiceMonitor;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -100,16 +101,14 @@ public class MetricsModule implements Module
       log.info(
           "Loaded %d monitors: %s",
           monitors.size(),
-          monitors.stream().map(monitor -> monitor.getClass().getName()).collect(Collectors.joining(", "))
-      );
+          monitors.stream().map(monitor -> monitor.getClass().getName()).collect(Collectors.joining(", ")));
     }
 
     return new MonitorScheduler(
         config.get(),
-        Execs.scheduledSingleThreaded("MonitorScheduler-%s"),
+        CronScheduler.newBuilder(Duration.ofSeconds(1L)).setThreadName("MonitorScheduler-%s").build(),
         emitter,
-        monitors
-    );
+        monitors);
   }
 
   @Provides


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #9283.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
This PR fixes the issue with MonitorScheduler which uses the ScheduledExecutorService which is prone to unbound clock drift. In this patch, I have replaced ScheduledExecutorService with [CronScheduler](https://github.com/TimeAndSpaceIO/CronScheduler) and added a method scheduleAtFixedRate which schedule the task at a given period and initialDelay. CronScheduler has similar methods like ScheduledExecutorService for scheduling the task periodically or at one shot but additionally it takes machine suspension into account thus making it resistant to clock drift.


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `ScheduledExecutors.java`
 * `MonitorScheduler.java`
 * `MetricsModule.java`
 * `Added dependency and license for io.timeandspace:cron-scheduler`
